### PR TITLE
Patch for session security (3.4.1)

### DIFF
--- a/Backend/SecretShareSession.php
+++ b/Backend/SecretShareSession.php
@@ -16,5 +16,4 @@ class SecretShareSession {
     }
 
 }
-
 ?>

--- a/_versioninfo.php
+++ b/_versioninfo.php
@@ -2,4 +2,4 @@
 /**
  * Provides the current version of the application. Used for cache busting. No need to edit this unless you want to bust the cache for some reason.
  */
-define('CURRENT_VERSION', '3.4.0');
+define('CURRENT_VERSION', '3.4.1');

--- a/public/index.php
+++ b/public/index.php
@@ -28,10 +28,17 @@ if(!defined('MAXIMUM_VIEWS')) {
 if(!defined('USE_DICEWARE_PASSWORD_GENERATOR')) {
     define('USE_DICEWARE_PASSWORD_GENERATOR', true);
 }
-
+//Start the session with secure cookie settings
+if($_SERVER['HTTP_HOST'] === 'localhost') {
+    ini_set('session.cookie_secure', '0');
+} else {
+    ini_set('session.cookie_secure', '1');
+}
+ini_set('session.cookie_httponly', '1');
+ini_set('session.use_strict_mode', '1');
+ini_set('session.cookie_samesite', 'Strict');
 session_start();
 $CSRF_TOKEN = SecretShareSession::initiateCsrfToken();
-
 $HANDLER = new SecretShareRoutingHandler($CSRF_TOKEN);
 
 $router = new Router;


### PR DESCRIPTION
**No breaking changes**

Adds same site, http, secure only to session cookies to protect the session ID.