### PR TITLE
Add cloudflare turnstile captcha (3.5.0)

### DIFF
--- a/Backend/SecretShareRoutingHandler.php
+++ b/Backend/SecretShareRoutingHandler.php
@@ -52,6 +52,18 @@ class SecretShareRoutingHandler {
                 http_response_code(403);
                 throw new Exception('CSRF violation detected. Please refresh the page and try again.');
             }
+            if(CLOUDFLARE_TURNSTILE_ENABLED) {
+                if(!isset($_POST['cf-turnstile-response'])) {
+                    throw new Exception('CAPTCHA response is required.');
+                }
+                $response = $_POST['cf-turnstile-response'] ?? '';
+                if(empty($response)) {
+                    throw new Exception('CAPTCHA response is required.');
+                }
+                if(!SecretShareTurnstile::checkTurnstileResponse($response)) {
+                    throw new Exception('CAPTCHA failed.');
+                }
+            }
     
             // Retrieve POST parameters
             $secret = $_POST['secret'] ?? '';
@@ -131,6 +143,18 @@ class SecretShareRoutingHandler {
             if (empty($token) || !isset($_SESSION['token']) || $token !== $_SESSION['token']) {
                 http_response_code(403);
                 throw new Exception('CSRF violation detected. Please refresh the page and try again.');
+            }
+            if(CLOUDFLARE_TURNSTILE_ENABLED) {
+                if(!isset($_POST['cf-turnstile-response'])) {
+                    throw new Exception('CAPTCHA response is required.');
+                }
+                $response = $_POST['cf-turnstile-response'] ?? '';
+                if(empty($response)) {
+                    throw new Exception('CAPTCHA response is required.');
+                }
+                if(!SecretShareTurnstile::checkTurnstileResponse($response)) {
+                    throw new Exception('CAPTCHA failed.');
+                }
             }
             // Retrieve secret from database
             $database = new SecretShareDatabase();

--- a/Backend/SecretShareTurnstile.php
+++ b/Backend/SecretShareTurnstile.php
@@ -1,0 +1,39 @@
+<?php
+
+class SecretShareTurnstile {
+
+    private const TURNSTILE_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+    public static function checkTurnstileResponse(string $response) : bool {
+        if(!defined('CLOUDFLARE_TURNSTILE_SECRET_KEY')) {
+            throw new Exception('CLOUDFLARE_TURNSTILE_SECRET_KEY is not defined');
+        }
+        return true;
+
+        $payload = [
+            'secret' => CLOUDFLARE_TURNSTILE_SECRET_KEY,
+            'response' => $response
+        ];
+        $json_payload = json_encode($payload);
+
+        try {
+            $ch = curl_init();
+            curl_setopt($ch, CURLOPT_URL, self::TURNSTILE_URL);
+            curl_setopt($ch, CURLOPT_POST, 1);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $json_payload);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            $response = curl_exec($ch);
+        curl_close($ch);
+        } catch (Exception $e) {
+            throw new Exception('Error contacting Cloudflare Turnstile to check CAPTCHA');
+        }
+        $response = json_decode($response, true);
+        
+        if($response['success'] == true) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/Views/home.php
+++ b/Views/home.php
@@ -64,9 +64,18 @@
                     <div class="form-text">This password will be required to view the secret. <strong>Strength:</strong> <span id="passwordStrength">None</span></div>
                     <div class="alert alert-warning form-text"><strong>WARNING:</strong> If you use your own password, the encryption key will be derived from the password. Choose a good password. If you lose this password, it will be impossible to view the contents of the secret.</div>
                 </div>
+                <?php if(CLOUDFLARE_TURNSTILE_ENABLED) { ?>
+                <div class="mb-3">
+                        <div
+                        class="cf-turnstile"
+                        data-sitekey="<?php echo CLOUDFLARE_TURNSTILE_SITE_KEY; ?>"
+                        data-callback="turnstileCallback"
+                        ></div>
+                </div>
+                <?php } ?>
                 <div class="mb-3">
                     <input type="hidden" name="token" value="<?php echo $this->CSRF_TOKEN; ?>">
-                    <button type="submit" class="btn btn-primary" id="submitButton">Save Secret</button>
+                    <button type="submit" class="btn btn-primary" id="submitButton" <?php if(CLOUDFLARE_TURNSTILE_ENABLED) echo 'disabled'; ?>>Save Secret</button>
                     <div class="spinner-border" role="status" id="loading" style="display: none;">
                         <span class="visually-hidden">Loading...</span>
                     </div>
@@ -98,6 +107,10 @@
     <script>
         const useDicewareForPasswordGeneration = <?php echo USE_DICEWARE_PASSWORD_GENERATOR ? 'true' : 'false'; ?>;
     </script>
+
     <script src="js/home.js?v=<?php echo CURRENT_VERSION; ?>"></script>
+    <?php if(CLOUDFLARE_TURNSTILE_ENABLED) { ?>
+        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
+    <?php } ?>
 </body>
 </html>

--- a/Views/viewSecret.php
+++ b/Views/viewSecret.php
@@ -23,11 +23,21 @@
                     <input type="password" id="password" class="form-control" required disabled>
                     <div class="form-text">This password was provided when the secret was created. If you do not have the password, you will not be able to retrieve the secret.</div>
                 </div>
+                <?php if(CLOUDFLARE_TURNSTILE_ENABLED) { ?>
+                    <div class="mb-3">
+                    <div
+                        class="cf-turnstile"
+                        data-sitekey="<?php echo CLOUDFLARE_TURNSTILE_SITE_KEY; ?>"
+                        data-callback="turnstileCallback"
+                        ></div>
+                    </div>
+                <?php } ?>
                 <div class="mb-3">
                     <input type="hidden" name="secretId" id="secretId" value="<?php echo $secretId; ?>">
                     <input type="hidden" name="csrfToken" id="csrfToken" value="<?php echo $this->CSRF_TOKEN; ?>">
-                    <button type="submit" class="btn btn-primary btn-lg" id="submitButton">Retrieve Secret</button>
-                    <div class="spinner-border" role="status" id="loading" style="display: none;">
+                    <input type="hidden" name="cf-turnstile-response" id="cfTurnstileResponse" value="">
+                    <button type="submit" class="btn btn-primary btn-lg" id="submitButton" <?php if(CLOUDFLARE_TURNSTILE_ENABLED) echo 'disabled'; ?>>Retrieve Secret</button>
+                    <div class="spinner-border" role="status" id="loading" style="<?php if(!CLOUDFLARE_TURNSTILE_ENABLED) echo 'display: none;'; ?>">
                         <span class="visually-hidden">Loading...</span>
                     </div>
                 </div>
@@ -53,8 +63,11 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="/js/encryption.js?v=<?php echo CURRENT_VERSION; ?>"></script>
     <script>
-        const csrfToken = "<?php echo $this->CSRF_TOKEN; ?>";
     </script>
+
     <script src="/js/retrieve.js?v=<?php echo CURRENT_VERSION; ?>"></script>
+    <?php if(CLOUDFLARE_TURNSTILE_ENABLED) { ?>
+        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
+    <?php } ?>
 </body>
 </html>

--- a/_config.sample.php
+++ b/_config.sample.php
@@ -63,5 +63,10 @@
 //Whether or not Diceware should be used on the custom password generator
 define('USE_DICEWARE_PASSWORD_GENERATOR', true);
 
+//Cloudflare Turnstile (added in 3.5.0, optional)
+define('CLOUDFLARE_TURNSTILE_ENABLED', false); //Set this to true to enable the Cloudflare Turnstile. This will require the user to complete a CAPTCHA before viewing the secret.
+define('CLOUDFLARE_TURNSTILE_SECRET_KEY', ''); //The secret key for the Cloudflare Turnstile
+define('CLOUDFLARE_TURNSTILE_SITE_KEY', ''); //The site key for the Cloudflare Turnstile
+
 //Installed: Set this to true once you have completed the /install portion (e.g. created the database tables).
 define('INSTALLED', false);

--- a/_versioninfo.php
+++ b/_versioninfo.php
@@ -2,4 +2,4 @@
 /**
  * Provides the current version of the application. Used for cache busting. No need to edit this unless you want to bust the cache for some reason.
  */
-define('CURRENT_VERSION', '3.4.1');
+define('CURRENT_VERSION', '3.5.0');

--- a/public/index.php
+++ b/public/index.php
@@ -13,7 +13,19 @@ require_once("../Backend/SecretShareParser.php");
 require_once("../Backend/SecretShareDatabase.php");
 require_once("../Backend/SecretShareCryptography.php");
 require_once("../Backend/SecretShareSession.php");
+require_once("../Backend/SecretShareTurnstile.php");
 require_once("../Backend/SecretShareRoutingHandler.php");
+
+if(!defined('CLOUDFLARE_TURNSTILE_ENABLED')) {
+    define('CLOUDFLARE_TURNSTILE_ENABLED', false);
+}
+
+if(CLOUDFLARE_TURNSTILE_ENABLED) {
+    if(!defined('CLOUDFLARE_TURNSTILE_SECRET_KEY') || !defined('CLOUDFLARE_TURNSTILE_SITE_KEY') || CLOUDFLARE_TURNSTILE_SECRET_KEY === '' || CLOUDFLARE_TURNSTILE_SITE_KEY === '') {
+        die("Cloudflare Turnstile is enabled, but the secret and site keys are not defined.");
+    }
+}
+
 //Fill for PBKDF2_ITERATIONS if not defined in _config.php
 if(!defined('PBKDF2_ITERATIONS')) {
     define('PBKDF2_ITERATIONS', 100000);

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -176,3 +176,7 @@ function checkPasswordStrength(password) {
         return "Great (if it's random)!";
     }
   }
+
+  function turnstileCallback(callback) {
+    $("#submitButton").prop("disabled", false);
+  }

--- a/public/js/retrieve.js
+++ b/public/js/retrieve.js
@@ -13,7 +13,8 @@ $(document).ready(async function() {
         submitBtn.prop("disabled", true);
         var secretId = $("#secretId").val();
         var payload = {
-            token: $("#csrfToken").val()
+            token: $("#csrfToken").val(),
+            'cf-turnstile-response' : $("#cfTurnstileResponse").val()
         };
         $.ajax({
             method: "POST",
@@ -114,4 +115,12 @@ async function useCustomPassword()
     else {
         return false;
     }
+}
+
+function turnstileCallback(callback)
+{
+    console.log("Turnstile callback");
+    $("#cfTurnstileResponse").val(callback);
+    $("#submitButton").prop("disabled", false);
+    $("#loading").hide();
 }


### PR DESCRIPTION
3.5.0 to latest - No breaking changes

## Adds
Cloudflare Turnstile CAPTCHA functionality to validate requests. Add to config to enable:
```
define('CLOUDFLARE_TURNSTILE_ENABLED', false); //Set this to true to enable the Cloudflare Turnstile. This will require the user to complete a CAPTCHA before viewing the secret.
define('CLOUDFLARE_TURNSTILE_SECRET_KEY', ''); //The secret key for the Cloudflare Turnstile
define('CLOUDFLARE_TURNSTILE_SITE_KEY', ''); //The site key for the Cloudflare Turnstile
```