### PR TITLE
3.5.1 - Critical Cloudflare Turnstile Bugfix

### DIFF
--- a/Backend/SecretShareTurnstile.php
+++ b/Backend/SecretShareTurnstile.php
@@ -5,10 +5,9 @@ class SecretShareTurnstile {
     private const TURNSTILE_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
     public static function checkTurnstileResponse(string $response) : bool {
-        if(!defined('CLOUDFLARE_TURNSTILE_SECRET_KEY')) {
-            throw new Exception('CLOUDFLARE_TURNSTILE_SECRET_KEY is not defined');
+        if(!defined('CLOUDFLARE_TURNSTILE_SECRET_KEY') || CLOUDFLARE_TURNSTILE_SECRET_KEY === '') {
+            throw new Exception('CLOUDFLARE_TURNSTILE_SECRET_KEY is not defined or is empty.');
         }
-        return true;
 
         $payload = [
             'secret' => CLOUDFLARE_TURNSTILE_SECRET_KEY,

--- a/_versioninfo.php
+++ b/_versioninfo.php
@@ -2,4 +2,4 @@
 /**
  * Provides the current version of the application. Used for cache busting. No need to edit this unless you want to bust the cache for some reason.
  */
-define('CURRENT_VERSION', '3.5.0');
+define('CURRENT_VERSION', '3.5.1');


### PR DESCRIPTION
Fixes a bug in CF Turnstile logic that always returned ``true``

