### PR TITLE
Fix missing theme icons on retrieve page (Fixes #14)

### DIFF
--- a/Views/viewSecret.php
+++ b/Views/viewSecret.php
@@ -6,6 +6,7 @@
     <title><?php echo UI_TITLE; ?></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="/css/main.css?v=<?php echo CURRENT_VERSION; ?>">
 </head>
 <body>


### PR DESCRIPTION
This PR fixes the missing icons in the theme selection buttons on the retrieve page.

Change summary:
- Include Bootstrap Icons CSS on `Views/viewSecret.php` to render the sun/moon/system icons.

Why:
- Without the Bootstrap Icons stylesheet, the `<i class="bi ...">` elements showed no icons when viewing a secret prior to retrieval.

Fixes #14.