### PR TITLE
Release 4.0.1

### DIFF
--- a/_versioninfo.php
+++ b/_versioninfo.php
@@ -2,4 +2,4 @@
 /**
  * Provides the current version of the application. Used for cache busting. No need to edit this unless you want to bust the cache for some reason.
  */
-define('CURRENT_VERSION', '4.0.0'); // Update this version when making changes that require cache busting
+define('CURRENT_VERSION', '4.0.1'); // Update this version when making changes that require cache busting


### PR DESCRIPTION
Prepare release 4.0.1

- Bump CURRENT_VERSION to 4.0.1 in `_versioninfo.php` (cache-busting and versioning)
- Include fix from PR #15: add Bootstrap Icons to `Views/viewSecret.php` so theme icons render on the retrieve page.

This release addresses issue #14 through the included PR.

References: #15. Fixes #14.